### PR TITLE
Deshabilitar botón al no haber seleccionado un orientador

### DIFF
--- a/front/src/pages/PrivatePages/AssignAdviserPage/AssignAdviserPage.jsx
+++ b/front/src/pages/PrivatePages/AssignAdviserPage/AssignAdviserPage.jsx
@@ -23,20 +23,19 @@ function AssignAdviserPage() {
   const [modifyAlert, setModifyAlert] = useState(false);
 
   useEffect(() => {
-    setIsEmpty(!cardAdviserIsVisible);
+    valor < 1 ? setIsEmpty(true) : setIsEmpty(false);
   });
 
   const { studentDetail, getOneStudent } = useGet();
 
   const { adviserList, getAllAdvisers } = useGet();
 
-
   useEffect(() => {
     getOneStudent(idStudent);
     getAllAdvisers();
   }, []);
 
-  const [valor, setValor] = useState(1);
+  const [valor, setValor] = useState(0);
   const { adviserDetail, getOneAdviser } = useGet();
 
   useEffect(() => {
@@ -49,8 +48,7 @@ function AssignAdviserPage() {
     formik.handleChange(e);
   };
 
-
-   const assignAdviser = async (idAdviser) => {
+  const assignAdviser = async (idAdviser) => {
     try {
       const options = {
         method: 'PUT',
@@ -68,7 +66,7 @@ function AssignAdviserPage() {
     } catch (err) {
       console.error(`${err.response.status}: ${err.response.statusText}`);
     }
-  }; 
+  };
 
   return (
     <div className='grid mobile:grid-cols-1 laptop:grid-cols-[234px_1fr]  gap-0'>
@@ -113,7 +111,6 @@ function AssignAdviserPage() {
                 onSubmit={(idAdviser) => {
                   assignAdviser(idAdviser);
                   setShowAlert(true);
-                  
                 }}
               >
                 {(formik) => (
@@ -128,13 +125,13 @@ function AssignAdviserPage() {
                     >
                       <div>
                         <Field
-                          className='border-[2px] w-[320px] h-10  rounded-lg border-graybackground mt-4 focus:outline-green' 
+                          className='border-[2px] w-[320px] h-10  rounded-lg border-graybackground mt-4 focus:outline-green'
                           name='idAdviser'
                           as='select'
                           onClick={() => setcardAdviserIsVisible(true)}
                           onChange={(e) => handleChange(e, formik)}
                         >
-                          <option hidden value={0}>
+                          <option hidden value=''>
                             Seleccionar orientador
                           </option>
                           {adviserList.map((elemento) => (


### PR DESCRIPTION
Se deshabilitó botón al no haber seleccionado un orientador y se muestra de forma predeterminada una card de orientadores vacía.